### PR TITLE
20170512 c friendly

### DIFF
--- a/MerkleSet.py
+++ b/MerkleSet.py
@@ -691,14 +691,15 @@ class MerkleSet:
             if r == FULL:
                 if t0 == MIDDLE or t0 == INVALID:
                     self._delete_from_leaf(toleaf, lowpos)
-                assert toleaf[:2] == toleaf[rtopos:rtopos + 2]
-                toleaf[:2] = to_bytes(topos, 2)
+                assert leaf_get_next_ptr(toleaf) == to_node.get_unused_ptr()
+                leaf_set_next_ptr(toleaf, topos)
                 return FULL, None
-        toleaf[rtopos:rtopos + 64] = fromleaf[rfrompos:rfrompos + 64]
+        to_node.set_hash(0, from_node.get_hash(0))
+        to_node.set_hash(1, from_node.get_hash(1))
         if lowpos is not None:
-            toleaf[rtopos + 64:rtopos + 66] = to_bytes(lowpos + 1, 2)
+            to_node.set_pos(0, lowpos)
         if highpos is not None:
-            toleaf[rtopos + 66:rtopos + 68] = to_bytes(highpos + 1, 2)
+            to_node.set_pos(1, highpos)
         return DONE, topos
 
     def _delete_from_leaf(self, leaf, pos):

--- a/MerkleSet.py
+++ b/MerkleSet.py
@@ -680,7 +680,7 @@ class MerkleSet:
         lowpos = None
         highpos = None
         if t0 == MIDDLE or t0 == INVALID:
-            r, lowpos = self._copy_between_leafs_inner(fromleaf, toleaf, from_bytes(fromleaf[rfrompos + 64:rfrompos + 66]) - 1)
+            r, lowpos = self._copy_between_leafs_inner(fromleaf, toleaf, from_node.get_pos(0))
             if r == FULL:
                 assert toleaf[:2] == toleaf[rtopos:rtopos + 2]
                 toleaf[:2] = to_bytes(topos, 2)

--- a/MerkleSet.py
+++ b/MerkleSet.py
@@ -125,9 +125,6 @@ class MerkleSet:
         self.pointers_to_arrays = {}
         self.rootblock = None
 
-        # Support C style address modelling
-        self._brk = 0x100000
-
     # Only used by test code, makes sure internal state is consistent
     def audit(self, hashes):
         newhashes = []

--- a/MerkleSet.py
+++ b/MerkleSet.py
@@ -682,8 +682,8 @@ class MerkleSet:
         if t0 == MIDDLE or t0 == INVALID:
             r, lowpos = self._copy_between_leafs_inner(fromleaf, toleaf, from_node.get_pos(0))
             if r == FULL:
-                assert toleaf[:2] == toleaf[rtopos:rtopos + 2]
-                toleaf[:2] = to_bytes(topos, 2)
+                assert leaf_get_next_ptr(toleaf) == to_node.get_unused_ptr()
+                leaf_set_next_ptr(toleaf, topos)
                 return FULL, None
         t1 = get_type(fromleaf, rfrompos + 32)
         if t1 == MIDDLE or t1 == INVALID:

--- a/MerkleSet.py
+++ b/MerkleSet.py
@@ -356,10 +356,11 @@ class MerkleSet:
 
     def _force_calculation_leaf(self, block, pos):
         pos = 4 + pos * 68
+        node = Node(block, pos)
         if get_type(block, pos) == INVALID:
-            block[pos:pos + 32] = self._force_calculation_leaf(block, from_bytes(block[pos + 64:pos + 66]) - 1)
+            block[pos:pos + 32] = self._force_calculation_leaf(block, node.get_pos(0))
         if get_type(block, pos + 32) == INVALID:
-            block[pos + 32:pos + 64] = self._force_calculation_leaf(block, from_bytes(block[pos + 66:pos + 68]) - 1)
+            block[pos + 32:pos + 64] = self._force_calculation_leaf(block, node.get_pos(1))
         return hashaudit(block[pos:pos + 64])
 
     # Convenience function

--- a/MerkleSet.py
+++ b/MerkleSet.py
@@ -680,10 +680,10 @@ class MerkleSet:
         lowpos = None
         highpos = None
         if t0 == MIDDLE or t0 == INVALID:
-            r, lowpos = self._copy_between_leafs_inner(fromleaf, toleaf, from_bytes(fromleaf[rfrompos + 64:rfrompos + 66]) - 1)
+            r, lowpos = self._copy_between_leafs_inner(fromleaf, toleaf, from_node.get_pos(0))
             if r == FULL:
-                assert toleaf[:2] == toleaf[rtopos:rtopos + 2]
-                toleaf[:2] = to_bytes(topos, 2)
+                assert leaf_get_next_ptr(toleaf) == to_node.get_unused_ptr()
+                leaf_set_next_ptr(toleaf, topos)
                 return FULL, None
         t1 = get_type(fromleaf, rfrompos + 32)
         if t1 == MIDDLE or t1 == INVALID:

--- a/MerkleSet.py
+++ b/MerkleSet.py
@@ -680,10 +680,10 @@ class MerkleSet:
         lowpos = None
         highpos = None
         if t0 == MIDDLE or t0 == INVALID:
-            r, lowpos = self._copy_between_leafs_inner(fromleaf, toleaf, from_node.get_pos(0))
+            r, lowpos = self._copy_between_leafs_inner(fromleaf, toleaf, from_bytes(fromleaf[rfrompos + 64:rfrompos + 66]) - 1)
             if r == FULL:
-                assert leaf_get_next_ptr(toleaf) == to_node.get_unused_ptr()
-                leaf_set_next_ptr(toleaf, topos)
+                assert toleaf[:2] == toleaf[rtopos:rtopos + 2]
+                toleaf[:2] = to_bytes(topos, 2)
                 return FULL, None
         t1 = get_type(fromleaf, rfrompos + 32)
         if t1 == MIDDLE or t1 == INVALID:

--- a/MerkleSet.py
+++ b/MerkleSet.py
@@ -698,15 +698,15 @@ class MerkleSet:
     def _delete_from_leaf(self, leaf, pos):
         assert pos >= 0
         rpos = 4 + pos * 68
+        node = Node(leaf, rpos)
         t = get_type(leaf, rpos)
         if t == MIDDLE or t == INVALID:
-            self._delete_from_leaf(leaf, from_bytes(leaf[rpos + 64:rpos + 66]) - 1)
+            self._delete_from_leaf(leaf, node.get_pos(0))
         t = get_type(leaf, rpos + 32)
         if t == MIDDLE or t == INVALID:
-            self._delete_from_leaf(leaf, from_bytes(leaf[rpos + 66:rpos + 68]) - 1)
-        leaf[rpos + 2:rpos + 68] = bytes(66)
-        leaf[rpos:rpos + 2] = leaf[:2]
-        leaf[:2] = to_bytes(pos, 2)
+            self._delete_from_leaf(leaf, node.get_pos(1))
+        node.make_unused(leaf_get_next_ptr(leaf))
+        leaf_set_next_ptr(leaf, pos)
 
     def _copy_leaf_to_branch(self, branch, branchpos, moddepth, leaf, leafpos):
         assert leafpos >= 0

--- a/MerkleSet.py
+++ b/MerkleSet.py
@@ -692,12 +692,10 @@ class MerkleSet:
         topos = toleaf.get_next_ptr()
         if topos == 0xFFFF:
             return FULL, None
-        rfrompos = 4 + frompos * 68
-        from_node = Node(fromleaf, rfrompos)
-        rtopos = 4 + topos * 68
-        to_node = Node(toleaf, rtopos)
+        from_node = fromleaf.get_node(frompos)
+        to_node = toleaf.get_node(topos)
         toleaf.set_next_ptr(to_node.get_unused_ptr())
-        t0 = get_type(fromleaf, rfrompos)
+        t0 = from_node.get_type(0)
         lowpos = None
         highpos = None
         if t0 == MIDDLE or t0 == INVALID:
@@ -706,9 +704,9 @@ class MerkleSet:
                 assert toleaf.get_next_ptr() == to_node.get_unused_ptr()
                 toleaf.set_next_ptr(topos)
                 return FULL, None
-        t1 = get_type(fromleaf, rfrompos + 32)
+        t1 = from_node.get_type(1)
         if t1 == MIDDLE or t1 == INVALID:
-            r, highpos = self._copy_between_leafs_inner(fromleaf, toleaf, from_bytes(fromleaf[rfrompos + 66:rfrompos + 68]) - 1)
+            r, highpos = self._copy_between_leafs_inner(fromleaf, toleaf, from_node.get_pos(1))
             if r == FULL:
                 if t0 == MIDDLE or t0 == INVALID:
                     self._delete_from_leaf(toleaf, lowpos)

--- a/MerkleSet.py
+++ b/MerkleSet.py
@@ -1013,8 +1013,8 @@ class MerkleSet:
                 if r == ONELEFT:
                     t1 = get_type(block, rpos + 32)
                     assert t1 != EMPTY
-                    block[rpos:rpos + 32] = val
-                    block[rpos + 64:rpos + 66] = bytes(2)
+                    node.set_hash(0, val)
+                    node.set_pos(0, -1)
                     if t1 == TERMINAL:
                         return FRAGILE, None
                     if t != INVALID and t1 != INVALID:
@@ -1026,7 +1026,7 @@ class MerkleSet:
                     if t != INVALID:
                         make_invalid(block, rpos)
                     return FRAGILE, None
-                self._catch_leaf(block, from_bytes(block[rpos + 64:rpos + 66]) - 1)
+                self._catch_leaf(block, node.get_pos(0))
                 if t == INVALID:
                     return DONE, None
                 make_invalid(block, rpos)
@@ -1039,15 +1039,15 @@ class MerkleSet:
                 return DONE, None
             elif t == TERMINAL:
                 t0 = get_type(block, rpos)
-                if block[rpos + 32:rpos + 64] == toremove:
+                if node.get_hash(1) == toremove:
                     if t0 == TERMINAL:
-                        left = block[rpos:rpos + 32]
+                        left = node.get_hash(0)
                         self._deallocate_leaf_node(block, pos)
                         return ONELEFT, left
-                    block[rpos + 32:rpos + 64] = bytes(32)
+                    node.set_hash(1, bytes(32))
                     return FRAGILE, None
-                if block[rpos:rpos + 32] == toremove:
-                    left = block[rpos + 32:rpos + 64]
+                if node.get_hash(0) == toremove:
+                    left = node.get_hash(1)
                     self._deallocate_leaf_node(block, pos)
                     return ONELEFT, left
                 return DONE, None

--- a/MerkleSet.py
+++ b/MerkleSet.py
@@ -762,11 +762,12 @@ class MerkleSet:
         assert 2 <= len(things) <= 3
         for thing in things:
             assert len(thing) == 32
-        pos = from_bytes(leaf[:2])
+        pos = leaf.get_next_ptr()
         if pos == 0xFFFF:
             return FULL, None
         lpos = pos * 68 + 4
-        leaf[:2] = leaf[lpos:lpos + 2]
+        node = leaf.get_node(pos)
+        leaf.set_next_ptr(from_bytes(leaf[lpos:lpos + 2]))
         things.sort()
         if len(things) == 2:
             leaf[lpos:lpos + 32] = things[0]
@@ -776,7 +777,7 @@ class MerkleSet:
         if bits[0] == bits[1] == bits[2]:
             r, laterpos = self._insert_leaf(things, leaf, depth + 1)
             if r == FULL:
-                leaf[:2] = to_bytes(pos, 2)
+                leaf.set_next_ptr(pos)
                 return FULL, None
             if bits[0] == 0:
                 leaf[lpos + 64:lpos + 66] = to_bytes(laterpos + 1, 2)
@@ -789,7 +790,7 @@ class MerkleSet:
         elif bits[0] == bits[1]:
             r, laterpos = self._insert_leaf([things[0], things[1]], leaf, depth + 1)
             if r == FULL:
-                leaf[:2] = to_bytes(pos, 2)
+                leaf.set_next_ptr(pos)
                 return FULL, None
             leaf[lpos + 32:lpos + 64] = things[2]
             leaf[lpos + 64:lpos + 66] = to_bytes(laterpos + 1, 2)
@@ -797,7 +798,7 @@ class MerkleSet:
         else:
             r, laterpos = self._insert_leaf([things[1], things[2]], leaf, depth + 1)
             if r == FULL:
-                leaf[:2] = to_bytes(pos, 2)
+                leaf.set_next_ptr(pos)
                 return FULL, None
             leaf[lpos:lpos + 32] = things[0]
             leaf[lpos + 66:lpos + 68] = to_bytes(laterpos + 1, 2)

--- a/MerkleSet.py
+++ b/MerkleSet.py
@@ -736,7 +736,7 @@ class MerkleSet:
 
     def _copy_leaf_to_branch(self, branch, branchpos, moddepth, leaf, leafpos):
         assert leafpos >= 0
-        rleafpos = 4 + leafpos * 68
+        node = leaf.get_node(leafpos)
         if moddepth == 0:
             active = self._deref(branch[:8])
             if active is None:
@@ -748,13 +748,13 @@ class MerkleSet:
             branch[branchpos:branchpos + 8] = self._addrof(active)
             branch[branchpos + 8:branchpos + 10] = to_bytes(newpos, 2)
             return
-        branch[branchpos:branchpos + 64] = leaf[rleafpos:rleafpos + 64]
-        t = get_type(leaf, rleafpos)
+        branch[branchpos:branchpos + 64] = node.get_hash(0) + node.get_hash(1)
+        t = node.get_type(0)
         if t == MIDDLE or t == INVALID:
-            self._copy_leaf_to_branch(branch, branchpos + 64, moddepth - 1, leaf, from_bytes(leaf[rleafpos + 64:rleafpos + 66]) - 1)
-        t = get_type(leaf, rleafpos + 32)
+            self._copy_leaf_to_branch(branch, branchpos + 64, moddepth - 1, leaf, node.get_pos(0))
+        t = node.get_type(1)
         if t == MIDDLE or t == INVALID:
-            self._copy_leaf_to_branch(branch, branchpos + 64 + self.subblock_lengths[moddepth - 1], moddepth - 1, leaf, from_bytes(leaf[rleafpos + 66:rleafpos + 68]) - 1)
+            self._copy_leaf_to_branch(branch, branchpos + 64 + self.subblock_lengths[moddepth - 1], moddepth - 1, leaf, node.get_pos(1))
 
     # returns (status, pos)
     # status can be INVALIDATING, FULL


### PR DESCRIPTION
Some trivial changes:

- Ensure that the code only does id() on objects that are allocated, confirming that all other slice copies are temporary, and that no address is used in tree construction that isn't the result of an allocation.
- Rename _ref and _deref to _deref and _addrof to make more sense in context.  _ref would make sense if this was an operation with a ref counting side effect, but here it's used to retrieve the object pointed to by a pointer.  _deref here retrieves a pointer to an allocated object.
- Rename flip_* to set_* for clarity.

What do you think about this?